### PR TITLE
Remove x86 from premake project generation

### DIFF
--- a/include/Engine/Utility/Core.h
+++ b/include/Engine/Utility/Core.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #ifdef _WIN32
-#ifdef _WIN64
+	#ifdef _WIN64
 		#define PLATFORM_WINDOWS
 	#else
 		#error "Windows X86 is not supported"
 	#endif
 #elif defined(__APPLE__) || defined(__MACH__)
-#include <TargetConditionals.h>
+	#include <TargetConditionals.h>
 	#if TARGET_IPHONE_SIMULATOR == 1
 		#error "IOS simulator not supported"
 	#elif TARGET_OS_IPHONE == 1
@@ -19,10 +19,10 @@
 		#error "Unknown Apple platform"
 	#endif
 #elif defined(__ANDROID__)
-#define PLATFORM_ANDROID
+	#define PLATFORM_ANDROID
 	#error "Android is not supported"
 #elif defined(__linux__)
-#define PLATFORM_LINUX
+	#define PLATFORM_LINUX
 #else
-#error "Unknown platform"
+	#error "Unknown platform"
 #endif

--- a/premake/utils.lua
+++ b/premake/utils.lua
@@ -10,7 +10,7 @@ function utils.get_platforms()
 	end
 
 	if os.ishost( 'windows' ) then
-		return os.is64bit() and { 'x64', 'x86' } or { 'x86' }
+		return { 'x64' }
 	end
 
 	local arch = os.outputof( 'uname -m' )


### PR DESCRIPTION
The x86 project fails to compile due to Core.h throwing an error, and we should only support x64 anyway.