### PR TITLE
Registry System.

### DIFF
--- a/include/Game/Registry/Registry.h
+++ b/include/Game/Registry/Registry.h
@@ -1,0 +1,33 @@
+//
+//	Created by MarcasRealAccount on 11. Nov. 2020
+//
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace gp1 {
+
+	template <typename T>
+	class Registry {
+	public:
+		static void RegisterElement(const std::string& id, T element) {
+			Registry<T>::m_Instance->m_Elements.insert({ id, element });
+		}
+
+		static const T* GetElement(const std::string& id) {
+			auto itr = Registry<T>::m_Instance->m_Elements.find(id);
+			if (itr != Registry<T>::m_Instance->m_Elements.end()) {
+				return &itr->second;
+			}
+			return nullptr;
+		}
+
+	private:
+		static Registry<T>* m_Instance;
+
+		std::unordered_map<std::string, T> m_Elements;
+	};
+
+} // namespace gp1

--- a/src/Game/Registry/Registry.cpp
+++ b/src/Game/Registry/Registry.cpp
@@ -1,0 +1,14 @@
+//
+//	Created by MarcasRealAccount on 11. Nov. 2020
+//
+
+#include "Game/Registry/Registry.h"
+
+namespace gp1 {
+
+	// Define a registry for type:
+	// Registry<T>* Registry<T>::m_Instance = new Registry<T>();
+	// Where T is the typename you want to use.
+	// To use that registry all you do is Registry<T>::RegisterElement() or Registry<T>::GetElement().
+
+} // namespace gp1


### PR DESCRIPTION
### Registry System
You can now register elements for later use.
Using `Registry<T>::RegisterElement()` or `Registry<T>::GetElement()`, where `T` is the type you want.
Though you still have to register it manually in a cpp file by doing `Registry<T>* Registry<T>::m_Instance = new Registry<T>();`.