### PR TITLE
Locale system

### DIFF
--- a/include/Engine/Utility/Locale/LocaleManager.h
+++ b/include/Engine/Utility/Locale/LocaleManager.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace gp1 {
+
+	namespace locale {
+
+		class LocaleManager {
+		public:
+			// Sets the localization to be used.
+			static void SetLocalization(const std::string& languageCode);
+			// Gets the current language code used.
+			static const std::string& GetLanguageCode();
+			// Gets the localized string, from the key.
+			static std::string GetLocalizedString(const std::string& key);
+
+		private:
+			static std::string m_LanguageCode;										// The current language loaded in.
+			static std::unordered_map<std::string, std::string> m_Localizations;	// The current localized strings.
+		};
+
+	} // namespace locale
+
+} // namespace gp1

--- a/src/Engine/Application.cpp
+++ b/src/Engine/Application.cpp
@@ -18,6 +18,8 @@
 
 #include "Engine/Audio/AudioCore.h"
 
+#include "Engine/Utility/Locale/LocaleManager.h"
+
 namespace gp1 {
 
 	TestEntity::TestEntity()
@@ -53,6 +55,7 @@ namespace gp1 {
 	}
 
 	Application::Application() {
+		locale::LocaleManager::SetLocalization("en-us");
 		Logger::Init();
 		AudioCore::Init();
 		m_Window.Init();

--- a/src/Engine/Utility/Locale/LocaleManager.cpp
+++ b/src/Engine/Utility/Locale/LocaleManager.cpp
@@ -1,0 +1,59 @@
+#include "Engine/Utility/Locale/LocaleManager.h"
+#include "Engine/Utility/Config/ConfigManager.h"
+#include "Engine/Utility/Config/ConfigFile.h"
+
+namespace gp1 {
+
+	namespace locale {
+
+		std::string LocaleManager::m_LanguageCode;
+		std::unordered_map<std::string, std::string> LocaleManager::m_Localizations;
+
+		void AddConfigsToMap(config::ConfigSection* section, std::unordered_map<std::string, std::string>& map, const std::string& currentSectionName = "") {
+			if (section == nullptr)
+				return;
+
+			// Loop through all configs in the section and insert them into the map.
+			auto configs = section->GetConfigs();
+			for (auto& config : configs) {
+				map.insert({ currentSectionName + config.first, config.second });
+			}
+
+			// Loop through all sections in the section and add all their configs into the map.
+			auto sections = section->GetSections();
+			for (auto& section : sections) {
+				AddConfigsToMap(section.second, map, currentSectionName + section.second->GetKey() + ".");
+			}
+		}
+
+		const std::string& LocaleManager::GetLanguageCode() {
+			return LocaleManager::m_LanguageCode;
+		}
+
+		void LocaleManager::SetLocalization(const std::string& languageCode) {
+			if (languageCode == LocaleManager::m_LanguageCode)
+				return;
+
+			// Clear the old localizations.
+			LocaleManager::m_Localizations.clear();
+
+			// Load the lang file as an .ini file and add all its configs to the localizations map.
+			config::ConfigFile* config = config::ConfigManager::GetConfigFilePath("locale/" + languageCode);
+			if (config) {
+				AddConfigsToMap(config, LocaleManager::m_Localizations);
+				delete config;	// Delete the config to save ram.
+				LocaleManager::m_LanguageCode = languageCode;
+			}
+		}
+
+		std::string LocaleManager::GetLocalizedString(const std::string& key) {
+			auto itr = LocaleManager::m_Localizations.find(key);
+			if (itr != LocaleManager::m_Localizations.end()) {
+				return itr->second;
+			}
+			return "";
+		}
+
+	} // namespace locale
+
+} // namespace gp1

--- a/src/Game/Assets/locale/en-us.ini
+++ b/src/Game/Assets/locale/en-us.ini
@@ -1,0 +1,1 @@
+hello = "This is a hello world message!"

--- a/src/Game/Assets/locale/no-nb.ini
+++ b/src/Game/Assets/locale/no-nb.ini
@@ -1,0 +1,1 @@
+hello = "Dette er en hallo verden melding!"

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -7,6 +7,7 @@
 #include "Engine/Events/KeyboardEvent.h"
 #include "Engine/Events/MouseEvent.h"
 #include "Engine/Renderer/DebugRenderer.h"
+#include "Engine/Utility/Locale/LocaleManager.h"
 
 namespace gp1 {
 
@@ -16,6 +17,13 @@ namespace gp1 {
 
 	Game::Game()
 		: m_Logger("Game"), Application() {
+
+		std::string message = locale::LocaleManager::GetLocalizedString("hello");
+		m_Logger.LogDebug("%s", message.c_str());
+		locale::LocaleManager::SetLocalization("no-nb");
+		message = locale::LocaleManager::GetLocalizedString("hello");
+		m_Logger.LogDebug("%s", message.c_str());
+		locale::LocaleManager::SetLocalization("this-does-not-exist");
 
 		// Load the sources
 		TestWAV = AudioSource::LoadFromFile("Sounds/TestWAV.wav");


### PR DESCRIPTION
# Locale System
It's meant to allow us multiple languages and it also uses the **Config System** (probably because I really like it, apart from a heap corruption issue from `delete[] buf` I got for some weird reason, so I had to change it to read into a `std::string` instead)
## How to use it
```cpp
// First include it
#include "Engine/Utility/Locale/LocaleManager"

// Now you can set the locale to use, though this should not be done anywhere but only where we can swap language or something.
// "en-us" is obviously the english translation.
gp1::locale::LocaleManager::SetLocalization("en-us");

// After that this can be used literally everywhere.
// "some_localized_string_key" can be anything as long as the key exists in the language file at "Assets/Locale/{locale}.ini"
std::string value = gp1::locale::LocaleManager::GetLocalizedString("some_localized_string_key");
```
## Info
So as a test I made two locales one **"en-us"** and one **"no-nb"** because I'm Norwegian and it was the easiest.
Where both locales hold the key **"hello"** and a value.
In **Game.cpp** I call the getter to get the value of **"hello"** in both locales.
And at the end I set it to a locale that does not exist as it should clear all its data at that point.
```cpp
std::string message = locale::LocaleManager::GetLocalizedString("hello");
m_Logger.LogDebug("%s", message.c_str());
locale::LocaleManager::SetLocalization("no-nb");
message = locale::LocaleManager::GetLocalizedString("hello");
m_Logger.LogDebug("%s", message.c_str());
locale::LocaleManager::SetLocalization("this-does-not-exist");
```
And the printed messages would be
```
[Game][14:35:20] Debug: This is a hello world message!
[Game][14:35:20] Debug: Dette er en hallo verden melding!
```