### PR TITLE
CVar System

### DIFF
--- a/include/Engine/Utility/CVar.h
+++ b/include/Engine/Utility/CVar.h
@@ -1,0 +1,64 @@
+//
+//	Created by Sausty on 18. May. 2021
+//
+
+#pragma once
+
+#include <string>
+#include <fstream>
+#include <iostream>
+
+namespace gp1
+{
+	template<typename T>
+	class CVar
+	{
+	public:
+		CVar(T initialiser, const std::string& name);
+
+		void LoadFromFile(std::ifstream& stream);
+
+		T Get() { return m_Value; }
+		void Set(T value) { m_Value = value; }
+
+		operator T() const {
+			return m_Value;
+		}
+
+		std::ostream& operator<<(std::ostream& os)
+		{
+			return os << m_Name << " : " << m_Value;
+		}
+
+		const std::string& GetName() const { return m_Name; }
+	private:
+		std::string m_Name;
+		T m_Value;
+	};
+
+	using CVar_Int = CVar<int>;
+	using CVar_Float = CVar<float>;
+	using CVar_String = CVar<std::string>;
+
+	template<typename T>
+	inline CVar<T>::CVar(T initialiser, const std::string& name)
+		: m_Value(initialiser), m_Name(name)
+	{
+	}
+
+	template<typename T>
+	inline void CVar<T>::LoadFromFile(std::ifstream& stream)
+	{
+		if (stream.is_open())
+		{
+			std::string name;
+			T value{};
+			stream >> name >> value;
+
+			if (name == m_Name)
+			{
+				m_Value = (T)value;
+			}
+		}
+	}
+}

--- a/include/Engine/Utility/CVarSystem.h
+++ b/include/Engine/Utility/CVarSystem.h
@@ -1,0 +1,29 @@
+//
+//	Created by Sausty on 18. May. 2021
+//
+
+#pragma once
+
+#include <Engine/Utility/CVar.h>
+#include <vector>
+
+namespace gp1
+{
+	class CVarSystem
+	{
+	public:
+		CVarSystem(const std::string& path);
+		~CVarSystem();
+
+		CVar_Int GetCVarInt(const std::string& name, int defaultValue);
+		CVar_String GetCVarString(const std::string& name, const std::string& defaultValue);
+		CVar_Float GetCVarFloat(const std::string& name, float defaultValue);
+	private:
+		std::vector<CVar_Int> m_CVarsInt;
+		std::vector<CVar_String> m_CVarsString;
+		std::vector<CVar_Float> m_CVarsFloat;
+
+		std::string m_Path;
+		std::ifstream m_Stream;
+	};
+}

--- a/include/Game/Game.h
+++ b/include/Game/Game.h
@@ -6,6 +6,7 @@
 
 #include <Engine/Application.h>
 #include <Engine/Utility/Logger.h>
+#include <Engine/Utility/CVarSystem.h>
 #include <Engine/Input/InputHandler.h>
 #include <Engine/Audio/Audio.h>
 
@@ -27,6 +28,7 @@ namespace gp1 {
 		void PlayFLACCallback(input::ButtonCallbackData data);
 	private:
 		Logger m_Logger;
+		CVarSystem m_CVarSystem;
 
 		// Audio Data
 		AudioSource TestMP3;

--- a/src/Engine/Utility/CVarSystem.cpp
+++ b/src/Engine/Utility/CVarSystem.cpp
@@ -1,0 +1,70 @@
+//
+//	Created by Sausty on 18. May. 2021
+//
+
+#include <Engine/Utility/CVarSystem.h>
+
+namespace gp1
+{
+	CVarSystem::CVarSystem(const std::string& path)
+		: m_Path(path)
+	{
+		m_Stream = std::ifstream(path);
+	}
+
+	CVarSystem::~CVarSystem()
+	{
+		m_Stream.close();
+	}
+
+	CVar_Int CVarSystem::GetCVarInt(const std::string& name, int defaultValue)
+	{
+		for (auto& cvar : m_CVarsInt)
+		{
+			if (cvar.GetName() == name)
+			{
+				return cvar;
+			}
+		}
+
+		// If not found, read from file
+		CVar_Int res(defaultValue, name);
+		res.LoadFromFile(m_Stream);
+		m_CVarsInt.push_back(res);
+		return res;
+	}
+
+	CVar_String CVarSystem::GetCVarString(const std::string& name, const std::string& defaultValue)
+	{
+		for (auto& cvar : m_CVarsString)
+		{
+			if (cvar.GetName() == name)
+			{
+				return cvar;
+			}
+		}
+
+		// If not found, read from file
+		CVar_String res(defaultValue, name);
+		res.LoadFromFile(m_Stream);
+		m_CVarsString.push_back(res);
+		return res;
+	}
+
+	CVar_Float CVarSystem::GetCVarFloat(const std::string& name, float defaultValue)
+	{
+		for (auto& cvar : m_CVarsFloat)
+		{
+			if (cvar.GetName() == name)
+			{
+				return cvar;
+			}
+		}
+
+		// If not found, read from file
+		CVar_Float res(defaultValue, name);
+		res.LoadFromFile(m_Stream);
+		m_CVarsFloat.push_back(res);
+		return res;
+	}
+}

--- a/src/Game/Assets/Configs/cvars.ini
+++ b/src/Game/Assets/Configs/cvars.ini
@@ -1,0 +1,3 @@
+width 1280
+height 720
+render_level medium

--- a/src/Game/Game.cpp
+++ b/src/Game/Game.cpp
@@ -7,6 +7,7 @@
 #include "Engine/Events/KeyboardEvent.h"
 #include "Engine/Events/MouseEvent.h"
 #include "Engine/Renderer/DebugRenderer.h"
+#include "Engine/Utility/CVarSystem.h"
 
 namespace gp1 {
 
@@ -15,7 +16,7 @@ namespace gp1 {
 	}
 
 	Game::Game()
-		: m_Logger("Game"), Application() {
+		: m_Logger("Game"), Application(), m_CVarSystem("Configs/cvars.ini") {
 
 		// Load the sources
 		TestWAV = AudioSource::LoadFromFile("Sounds/TestWAV.wav");
@@ -61,6 +62,14 @@ namespace gp1 {
 		DebugRenderer::DebugDrawABox({ 0, -2, -7 }, 10.0f);
 		DebugRenderer::DebugDrawABox({ -1, -2, -7 }, 10.0f);
 		DebugRenderer::DebugDrawABox({ -2, -2, -7 }, 10.0f);
+
+		CVar_Int width = m_CVarSystem.GetCVarInt("width", 1280);
+		CVar_Int height = m_CVarSystem.GetCVarInt("height", 720);
+		CVar_String level = m_CVarSystem.GetCVarString("render_level", "medium");
+
+		std::cout << width << std::endl;
+		std::cout << height << std::endl;
+		std::cout << level.Get() << std::endl;
 	}
 
 	void Game::LookCallback(input::AxisCallbackData data) {


### PR DESCRIPTION
Implemented a simple CVar system to help manage internal game/engine settings.
3 types are supported : Ints, floats and strings.

Here is an example of how the CVar system can be used:

Configs/cvars.ini
```
some_int 3
```

example.cpp
```cpp
CVarSystem system("Configs/cvars.ini");

CVar_Int some_int = system.GetCVarInt("some_int", 1);
assert(some_int.Get() == 3);
```