### PR TITLE
Added Vulkan Queues and Logging system

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "ThirdParty/inipp"]
 	path = ThirdParty/inipp
 	url = https://github.com/mcmtroffaes/inipp.git
+[submodule "ThirdParty/spdlog"]
+	path = ThirdParty/spdlog
+	url = https://github.com/gabime/spdlog

--- a/Carbonite/Include/Graphics/Device.h
+++ b/Carbonite/Include/Graphics/Device.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <optional>
+
+#include "Queue.h"
 #include "Surface.h"
 
 namespace Graphics
@@ -47,6 +50,11 @@ namespace Graphics
 			return m_EnabledExtensions;
 		}
 
+		auto getQueues() const
+		{
+			return m_queues;
+		}
+
 		bool isLayerEnabled(std::string_view name) const
 		{
 			return getLayerVersion(name);
@@ -71,5 +79,7 @@ namespace Graphics
 
 		std::vector<DeviceLayer>     m_Layers;
 		std::vector<DeviceExtension> m_Extensions;
+
+		Queue m_queues;
 	};
 } // namespace Graphics

--- a/Carbonite/Include/Graphics/Queue.h
+++ b/Carbonite/Include/Graphics/Queue.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <vulkan/vulkan.hpp>
+
+namespace Graphics
+{
+	struct Queue
+	{
+		unsigned  graphicsFamilyIndex;
+		vk::Queue graphicsQueue;
+	};
+} // namespace Graphics

--- a/Carbonite/Include/Graphics/Queue.h
+++ b/Carbonite/Include/Graphics/Queue.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include <vulkan/vulkan.hpp>
 
 namespace Graphics
@@ -7,6 +9,8 @@ namespace Graphics
 	struct Queue
 	{
 		std::uint32_t graphicsFamilyIndex;
+		std::uint32_t presentFamilyIndex;
 		vk::Queue     graphicsQueue;
+		vk::Queue     presentQueue;
 	};
 } // namespace Graphics

--- a/Carbonite/Include/Graphics/Queue.h
+++ b/Carbonite/Include/Graphics/Queue.h
@@ -6,7 +6,7 @@ namespace Graphics
 {
 	struct Queue
 	{
-		unsigned  graphicsFamilyIndex;
-		vk::Queue graphicsQueue;
+		std::uint32_t graphicsFamilyIndex;
+		vk::Queue     graphicsQueue;
 	};
 } // namespace Graphics

--- a/Carbonite/Include/Log.h
+++ b/Carbonite/Include/Log.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <memory>
+
+#include <spdlog/spdlog.h>
+
+namespace Log
+{
+
+	std::shared_ptr<spdlog::logger> getClientLogger();
+
+	void init();
+
+	template <typename... Ts>
+	void trace(Ts&&... args)
+	{
+		getClientLogger()->trace(std::forward<Ts>(args)...);
+	}
+
+	template <typename... Ts>
+	void info(Ts&&... args)
+	{
+		getClientLogger()->info(std::forward<Ts>(args)...);
+	}
+
+	template <typename... Ts>
+	void debug(Ts&&... args)
+	{
+		getClientLogger()->debug(std::forward<Ts>(args)...);
+	}
+
+	template <typename... Ts>
+	void warn(Ts&&... args)
+	{
+		getClientLogger()->warn(std::forward<Ts>(args)...);
+	}
+
+	template <typename... Ts>
+	void error(Ts&&... args)
+	{
+		getClientLogger()->error(std::forward<Ts>(args)...);
+	}
+
+	template <typename... Ts>
+	void critical(Ts&&... args)
+	{
+		getClientLogger()->critical(std::forward<Ts>(args)...);
+	}
+} // namespace Log

--- a/Carbonite/Source/Graphics/CommandPool.cpp
+++ b/Carbonite/Source/Graphics/CommandPool.cpp
@@ -102,7 +102,9 @@ namespace Graphics
 
 	void CommandPool::createImpl()
 	{
-		vk::CommandPoolCreateInfo createInfo = { {}, 0 /* queue.getQueueFamily() */ };
+		vk::CommandPoolCreateInfo createInfo;
+
+		createInfo.setQueueFamilyIndex(m_Device->getQueues().graphicsFamilyIndex);
 
 		m_Handle = m_Device->getHandle().createCommandPool(createInfo);
 	}

--- a/Carbonite/Source/Graphics/Debug/Debug.cpp
+++ b/Carbonite/Source/Graphics/Debug/Debug.cpp
@@ -19,7 +19,7 @@ namespace Graphics
 	void Debug::PopulateCreateInfo(vk::DebugUtilsMessengerCreateInfoEXT& createInfo)
 	{
 		createInfo.messageSeverity = vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose | vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo | vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning | vk::DebugUtilsMessageSeverityFlagBitsEXT::eError;
-		createInfo.messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
+		createInfo.messageType     = vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral | vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation | vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
 		createInfo.pfnUserCallback = Debug::DebugCallback;
 	}
 
@@ -63,7 +63,7 @@ namespace Graphics
 
 	VkBool32 Debug::DebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, [[maybe_unused]] void* pUserData)
 	{
-		std::string message = "VK Validation Layer " + GetSeverity(messageSeverity) + " (" + GetTypes(messageTypes) + "): " + pCallbackData->pMessage + "\n";
+		std::string message = pCallbackData->pMessage;
 		switch (static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>(messageSeverity))
 		{
 		case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:

--- a/Carbonite/Source/Graphics/Debug/Debug.cpp
+++ b/Carbonite/Source/Graphics/Debug/Debug.cpp
@@ -1,4 +1,5 @@
 #include "Graphics/Debug/Debug.h"
+#include "Log.h"
 
 #include <iostream>
 
@@ -63,11 +64,30 @@ namespace Graphics
 	VkBool32 Debug::DebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, [[maybe_unused]] void* pUserData)
 	{
 		std::string message = "VK Validation Layer " + GetSeverity(messageSeverity) + " (" + GetTypes(messageTypes) + "): " + pCallbackData->pMessage + "\n";
-		if (messageSeverity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
-			std::cerr << message;
-		else
-			std::cout << message;
-		return 0;
+		switch (static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>(messageSeverity))
+		{
+		case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:
+			Log::trace(message);
+			break;
+
+		case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo:
+			Log::info(message);
+			break;
+
+		case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning:
+			Log::warn(message);
+			break;
+
+		case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
+			Log::error(message);
+			break;
+
+		default:
+			Log::debug(message);
+			break;
+		}
+
+		return VK_FALSE;
 	}
 
 	Debug::Debug(Instance& instance)

--- a/Carbonite/Source/Graphics/Device.cpp
+++ b/Carbonite/Source/Graphics/Device.cpp
@@ -230,6 +230,13 @@ namespace Graphics
 					found = true;
 					break;
 				}
+
+				// https://vulkan.lunarg.com/doc/view/1.2.189.0/mac/1.2-extensions/vkspec.html#VUID-VkDeviceCreateInfo-pProperties-04451
+				if (extensionName == "VK_KHR_portability_subset")
+				{
+					m_EnabledExtensions.push_back({ extensionName, availExtension.specVersion });
+					break;
+				}
 			}
 			if (found) continue;
 		}

--- a/Carbonite/Source/Log.cpp
+++ b/Carbonite/Source/Log.cpp
@@ -1,0 +1,32 @@
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+#include "Log.h"
+
+namespace
+{
+
+	static std::shared_ptr<spdlog::logger> s_coreLogger;
+	static std::shared_ptr<spdlog::logger> s_clientLogger;
+
+} // namespace
+
+namespace Log
+{
+
+	void init()
+	{
+		spdlog::set_pattern("[%T.%f][%^%8l%$][%7t] %v");
+
+#if defined(NDEBUG)
+		s_clientLogger->set_level(spdlog::level::level_enum::err);
+#else
+		s_clientLogger->set_level(spdlog::level::level_enum::trace);
+#endif // NDEBUG
+	}
+
+	std::shared_ptr<spdlog::logger> getClientLogger()
+	{
+		return s_clientLogger;
+	}
+
+} // namespace Log

--- a/Carbonite/Source/Log.cpp
+++ b/Carbonite/Source/Log.cpp
@@ -20,7 +20,7 @@ namespace Log
 #if defined(NDEBUG)
 		s_clientLogger->set_level(spdlog::level::level_enum::err);
 #else
-		s_clientLogger->set_level(spdlog::level::level_enum::trace);
+		s_clientLogger->set_level(spdlog::level::level_enum::info);
 #endif // NDEBUG
 	}
 

--- a/Carbonite/Source/Log.cpp
+++ b/Carbonite/Source/Log.cpp
@@ -5,7 +5,6 @@
 namespace
 {
 
-	static std::shared_ptr<spdlog::logger> s_coreLogger;
 	static std::shared_ptr<spdlog::logger> s_clientLogger;
 
 } // namespace
@@ -15,6 +14,7 @@ namespace Log
 
 	void init()
 	{
+		s_clientLogger = spdlog::stderr_color_mt("Carbonite");
 		spdlog::set_pattern("[%T.%f][%^%8l%$][%7t] %v");
 
 #if defined(NDEBUG)

--- a/Carbonite/Source/Main.cpp
+++ b/Carbonite/Source/Main.cpp
@@ -5,6 +5,7 @@
 #include "Graphics/Surface.h"
 #include "Graphics/Sync/Fence.h"
 #include "Graphics/Sync/Semaphore.h"
+#include "Log.h"
 
 #include <GLFW/glfw3.h>
 
@@ -15,19 +16,21 @@
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
+	Log::init();
+
 	try
 	{
 		// Initialize GLFW
 		if (!glfwInit())
 		{
-			std::cerr << "GLFW failed to initialize!\n";
+			Log::error("GLFW failed to initialize!");
 			return EXIT_FAILURE;
 		}
 
 		// Check for vulkan support
 		if (!glfwVulkanSupported())
 		{
-			std::cerr << "Vulkan is not supported on this system!\n";
+			Log::error("Vulkan is not supported on this system!");
 			return EXIT_FAILURE;
 		}
 
@@ -154,7 +157,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 	}
 	catch (const std::exception& e)
 	{
-		std::cerr << e.what() << std::endl;
+		Log::critical(e.what());
 		return EXIT_FAILURE;
 	}
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -221,8 +221,8 @@ end
 		filter("system:macosx")
 			libdirs({ vulkanSDKPath .. "/lib/" })
 			links({
-				"libvulkan.1.dylib",
-				"libglslang.a",
+				"vulkan",
+				"glslang",
 				"CoreGraphics.framework",
 				"IOKit.framework",
 				"AppKit.framework"

--- a/premake5.lua
+++ b/premake5.lua
@@ -239,7 +239,8 @@ end
 			"%{wks.location}/ThirdParty/VMA/include/",
 			"%{wks.location}/ThirdParty/ImGUI/",
 			"%{wks.location}/ThirdParty/STB/",
-			"%{wks.location}/ThirdParty/inipp/inipp/"
+			"%{wks.location}/ThirdParty/inipp/inipp/",
+			"%{wks.location}/ThirdParty/spdlog/include/"
 		})
 
 		includedirs({


### PR DESCRIPTION
- Added graphics and presentation queue support criteria to physical device selection.
- Created graphics (and presentation queue if necessary) on `Device.createImpl()`.
- Added `Queue` struct to hold queue family indices and queues for a given `Device`.
- Added `Device.getQueues()` to retrieve said `Queue` struct.
- Added spdlog submodule and logging API. 
```cpp
#include "Log.h"

...

Log::trace(...); 
Log::info(...);
Log::warning(...);
Log::error(...);
Log::critical(...);
```
- Replaced `std::cerr` in `Main.cpp` and `Graphics/Debug.cpp` with our new logging API.